### PR TITLE
Update miniconda installer URL

### DIFF
--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME=/home/user
 WORKDIR /workspace
 
 # Install Miniconda
-RUN curl -so ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN curl -so ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && chmod +x ~/miniconda.sh \
     && ~/miniconda.sh -b -p ~/miniconda \
     && rm ~/miniconda.sh \


### PR DESCRIPTION
Hello,

Thank you for sharing this repository. These image files contain all of the required modules for modern chemoinformatics (e.g. rdkit, cuda, jupyter etc...)!!

This PR is for updating miniconda URL to download installer. Maybe due to the old URL, the recent docker build has failed.